### PR TITLE
Add video and figure handling.

### DIFF
--- a/R/lesson_to_html.R
+++ b/R/lesson_to_html.R
@@ -8,6 +8,12 @@ makechunk_silent <- function(item) {
   paste0(out, collapse="\n")
 }
 
+makelink <- function(item) {
+  out <- c("[link](", item, ")")
+  paste0(out, collapse="\n")
+}
+
+
 #' @importFrom stringr str_split str_trim
 makemult <- function(item) {
   answers <- unlist(str_split(item, ";"))
@@ -51,6 +57,16 @@ makemd.script <- function(unit) {
   paste(unit[["Output"]],
         makechunk(script_contents),
         sep = "\n\n")
+}
+
+makemd.video <- function(unit) {
+  paste(unit[['Output']],makelink(unit[['VideoLink']]),
+        sep="\n\n")
+}
+
+makemd.figure <- function(unit) {
+  paste(unit[['Output']], "Image not displayed", 
+        sep="\n\n")
 }
 
 #' Turn a swirl lesson into a pretty webpage


### PR DESCRIPTION
Currently lesson_to_html() does not handle video or figure question types.  The proposed figure handling is a solution, but perhaps not what could ultimately be achieved. However the diversity of what people can do with the scripts in figures makes me think that it's better to let people use the function and just not have the figures than to have the function unusable if you have used this type of question.
