### PR TITLE
Information when a unit type does not exist

### DIFF
--- a/R/lesson_to_html.R
+++ b/R/lesson_to_html.R
@@ -19,7 +19,7 @@ makemult <- function(item) {
 makemd <- function(unit) UseMethod("makemd")
 
 makemd.default <- function(unit) {
-  stop("No unit class specified!", unit)
+  paste0("This type of question cannot currently be converted to html: ", unit)
 }
 
 makemd.text <- function(unit) {


### PR DESCRIPTION
Currently when running lesson_to_html() a unit type (class) that does not exist results in the processing stopping completely and a somewhat hard to understand message (especially for people who haven't looked at the Swirlify source).  This change will simply put the message into the generated html while allowing processing to continue.
