### PR TITLE
Add check for potential course name inconsistencies

### DIFF
--- a/R/test_lesson.R
+++ b/R/test_lesson.R
@@ -74,6 +74,10 @@ test_lesson_by_name <- function(){
   lesson_dir_path <- getOption("swirlify_lesson_dir_path")
   les <- yaml.load_file(getOption("swirlify_lesson_file_path"))
   
+  # Get name of course folder from path
+  # and replace underscores with spaces
+  course_folder_name <- gsub(pattern = "_", replacement = " ", basename(course_dir_path))
+  
 #   for (R_file in c("customTests.R", "initLesson.R")){
 #     R_file_path <- file.path(lesson_dir_path, R_file)
 #     if(file.exists(R_file_path)) source(R_file_path,local = e)
@@ -86,6 +90,12 @@ test_lesson_by_name <- function(){
       for(i in c("Course", "Lesson", "Author", "Type", "Version")){
         if(is.null(question[[i]])) message("Please provide a value for the ",
                                                   i, " key in the meta question.")
+      }
+      if(question[["Course"]] != course_folder_name) {
+        message("Course name '" , question[["Course"]] , "' for ", 
+                getOption("swirlify_lesson_name"), "\n", 
+                "is inconsistent with the ", "(directory) course name: '", 
+                course_folder_name, "'")
       }
     } else if(question$Class == "cmd_question"){
       for(i in c("Output", "CorrectAnswer", "AnswerTests", "Hint")){

--- a/R/test_lesson.R
+++ b/R/test_lesson.R
@@ -34,6 +34,9 @@ test_lesson <- function(){
 test_course <- function(){
   lesson_file_check()
   
+  # Get currently set lesson
+  current_lesson_file_path <- getOption("swirlify_lesson_file_path")
+  
   if(!any(file.exists(file.path(getOption("swirlify_course_dir_path"), c("LICENSE.txt", "LICENSE", "LICENCE.txt", "LICENCE"))))){
     message("It seems this course does not contian a LICENSE.txt file.\nYou can easily add a license with add_license().\n")
   }
@@ -59,6 +62,8 @@ test_course <- function(){
     set_lesson(path_to_yaml = lesson, open_lesson = FALSE, silent = TRUE)
     test_lesson_by_name()
   }
+  # Re-set lesson to restore to orginal state
+  set_lesson(current_lesson_file_path)
 }
 
 # Test all cmd and mult questions of any lesson of current course.

--- a/tests/testthat/test_test_course.R
+++ b/tests/testthat/test_test_course.R
@@ -1,0 +1,56 @@
+context("Test test_course()")
+
+path <- tempdir()
+
+setwd(path)
+
+new_lesson("Test Lesson 1", "Test Course", open_lesson = FALSE)
+add_license(author = "Test Author")
+add_to_manifest()
+wq_command("0", "0", "0", "0")
+wq_message("0")
+
+new_lesson("Test Lesson 2", "Test Course", open_lesson = FALSE)
+add_to_manifest()
+wq_command("0", "0", "0", "0")
+wq_message("0")
+
+test_lesson_2_path <- file.path(getOption("swirlify_lesson_dir_path"), "lesson.yaml")
+
+# Overwrite lesson.yaml for Test Lesson 2
+# replacing "Test Course" with "Inconsistent Course Name"
+updated_yaml <- sub("Test Course", "Inconsistent Course Name", 
+                     readLines(test_lesson_2_path))
+cat(updated_yaml, file = test_lesson_2_path, sep = "\n")
+
+new_lesson("Test Lesson 3", "Test Course", open_lesson = FALSE)
+add_to_manifest()
+wq_command("0", "0", "0", "0")
+wq_message("0")
+
+
+zz <- file(file.path(path, "test.log"), open = "wt")
+sink(zz)
+sink(zz, type = "message")
+
+test_course()
+
+sink(type = "message")
+sink()
+
+correct_output <- c("##### Begin testing: Test Lesson 1 #####",
+                    "##### End testing: Test Lesson 1 #####",
+                    "",
+                    "##### Begin testing: Test Lesson 2 #####",
+                    "Course name 'Inconsistent Course Name' for Test Lesson 2",
+                    "is inconsistent with the (directory) course name: 'Test Course'",
+                    "##### End testing: Test Lesson 2 #####",
+                    "",
+                    "##### Begin testing: Test Lesson 3 #####",
+                    "##### End testing: Test Lesson 3 #####")
+
+test_that("test_course() passes with message about inconsistent course name", {
+  expect_true(all(correct_output %in% readLines(file.path(path, "test.log"))))
+})
+
+unlink(getOption("swirlify_course_dir_path"), recursive = TRUE, force = TRUE)


### PR DESCRIPTION
Add a basic check to test_course()/test_lesson() to identify potential course name inconsistencies in lesson.yaml files, and also include a test for this test function. This resolves issue #33.
